### PR TITLE
sys: introduce bundled building

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libevent-sys/libevent"]
+	path = libevent-sys/libevent
+	url = https://github.com/libevent/libevent.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,10 @@ repository = "https://github.com/jmagnuson/libevent-rs"
 license = "MIT/Apache-2.0"
 edition = "2018"
 
+[features]
+default = []
+static = [ "libevent-sys/static" ]
+bundled = [ "static", "libevent-sys/bundled" ]
+
 [dependencies]
+libevent-sys = { version = "0.2", path = "libevent-sys" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,11 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [features]
-default = [ "threading" ]
+default = [ "openssl", "threading" ]
 static = [ "libevent-sys/static" ]
 bundled = [ "static", "libevent-sys/bundled" ]
+openssl = [ "libevent-sys/openssl" ]
+openssl_bundled = [ "libevent-sys/openssl_bundled", "threading" ]
 threading = [ "libevent-sys/threading" ]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,10 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [features]
-default = []
+default = [ "threading" ]
 static = [ "libevent-sys/static" ]
 bundled = [ "static", "libevent-sys/bundled" ]
+threading = [ "libevent-sys/threading" ]
 
 [dependencies]
 libevent-sys = { version = "0.2", path = "libevent-sys" }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@ Rust bindings to the [libevent] async I/O framework.
 
 Check out the [hacking] branch for now.
 
+### Sysem Requirements
+
+* `libclang` is required by [bindgen] which is used to generate the Rust
+  bindings. See [bindgen requirements] for more information. Also ensure that
+  `LIBCLANG_PATH` is set, as some systems do not do so by default.
+
+* `cmake` if self-building via the `bundled` feature. The current bundled
+  release is `release-2.1.11-stable`.
+
+* `pkg-config` if not self-building via the `bundled` feature.
+
 
 [libevent]: https://libevent.org/
 [hacking]: https://github.com/jmagnuson/libevent-rs/tree/hacking
+[bindgen]: https://crates.io/crates/bindgen
+[bindgen requirements]: https://rust-lang.github.io/rust-bindgen/requirements.html

--- a/libevent-sys/Cargo.toml
+++ b/libevent-sys/Cargo.toml
@@ -15,13 +15,19 @@ links = "event"
 build = "build.rs"
 
 [features]
-default = [ "pkg-config", "threading" ]
+default = [ "pkg-config", "openssl", "threading" ]
 static = []
 bundled = [ "static", "cmake" ]
+openssl = [ "openssl-sys" ]
+openssl_bundled = [ "openssl-sys/vendored", "threading" ]
 threading = []
 
 # features for development
 verbose_build = []
+
+[dependencies.openssl-sys]
+version = "0.9"
+optional = true
 
 [build-dependencies]
 bindgen = "0.53"

--- a/libevent-sys/Cargo.toml
+++ b/libevent-sys/Cargo.toml
@@ -15,8 +15,11 @@ links = "event"
 build = "build.rs"
 
 [features]
+default = [ "pkg-config" ]
 static = []
+bundled = [ "static", "cmake" ]
 
 [build-dependencies]
-bindgen = "^0.45"
-pkg-config = "^0.3"
+bindgen = "0.53"
+cmake = { version = "0.1", optional = true }
+pkg-config = { version = "0.3", optional = true }

--- a/libevent-sys/Cargo.toml
+++ b/libevent-sys/Cargo.toml
@@ -19,6 +19,9 @@ default = [ "pkg-config" ]
 static = []
 bundled = [ "static", "cmake" ]
 
+# features for development
+verbose_build = []
+
 [build-dependencies]
 bindgen = "0.53"
 cmake = { version = "0.1", optional = true }

--- a/libevent-sys/Cargo.toml
+++ b/libevent-sys/Cargo.toml
@@ -15,9 +15,10 @@ links = "event"
 build = "build.rs"
 
 [features]
-default = [ "pkg-config" ]
+default = [ "pkg-config", "threading" ]
 static = []
 bundled = [ "static", "cmake" ]
+threading = []
 
 # features for development
 verbose_build = []

--- a/libevent-sys/build.rs
+++ b/libevent-sys/build.rs
@@ -1,18 +1,117 @@
 use std::env;
 use std::path::PathBuf;
 
-use bindgen;
-use pkg_config;
+#[cfg(feature = "bundled")]
+fn build_libevent(libevent_path: impl AsRef<std::path::Path>) -> PathBuf {
+    let mut config = cmake::Config::new(libevent_path);
+
+    // TODO: Or just both and decide elsewhere?
+    if cfg!(feature = "static") {
+        config.define("EVENT__LIBRARY_TYPE", "STATIC");
+    } else {
+        config.define("EVENT__LIBRARY_TYPE", "SHARED");
+    }
+
+    // Disable unnecessary dev-only features
+    {
+        config.define("EVENT__DISABLE_BENCHMARK", "ON")
+            .define("EVENT__DISABLE_TESTS", "ON")
+            .define("EVENT__DISABLE_REGRESS", "ON")
+            .define("EVENT__DISABLE_SAMPLES", "ON");
+
+        // TODO: Address policy warnings for cross-compilation?
+        /*config.define("CMAKE_POLICY_DEFAULT_CMP0056", "NEW")
+            .define("CMAKE_POLICY_DEFAULT_CMP0066", "NEW")*/
+    }
+
+    let dst = config.build();
+
+    println!("cargo:rustc-link-search={}/lib", dst.display());
+
+    // Library 'event' is considered deprecated, so link each sub-component
+    // individually.
+    println!("cargo:rustc-link-lib=static=event_core");
+    println!("cargo:rustc-link-lib=static=event_extra");
+
+    println!("cargo:include={}/include", dst.display());
+
+    dst
+}
+
+#[cfg(not(feature = "bundled"))]
+fn run_pkg_config() -> Option<Vec<String>> {
+    use std::collections::HashSet;
+
+    let mut pkg = pkg_config::Config::new();
+    pkg.cargo_metadata(true)
+        .atleast_version("2")
+        .statik(cfg!(feature = "static"));
+
+    let mut include_paths = HashSet::new();
+
+    if let Ok(mut lib) = pkg.probe("libevent_core") {
+        include_paths.extend(lib.include_paths.drain(..));
+    } else {
+        return None;
+    }
+
+    {
+        let mut lib = pkg.probe("libevent_extra").unwrap();
+        include_paths.extend(lib.include_paths.drain(..));
+    }
+
+    let include_paths = include_paths.drain().map(|path| {
+        let path_s = path.into_os_string().into_string().unwrap();
+        println!("cargo:include={}", &path_s);
+        path_s
+    }).collect();
+
+    Some(include_paths)
+}
+
+#[cfg(feature = "bundled")]
+fn find_libevent() -> Option<Vec<String>> {
+    use std::path::Path;
+    use std::process::Command;
+
+    if !Path::new("libevent/.git").exists() {
+        Command::new("git").args(&["submodule", "update", "--init"])
+            .status().expect("Running `git submodule init` failed.");
+    } else {
+        Command::new("git").args(&["submodule", "update", "--recursive"])
+            .status().expect("Running `git submodule update` failed.");
+    }
+
+    Some(vec![format!("{}/include", build_libevent("libevent").display())])
+}
+#[cfg(not(feature = "bundled"))]
+fn find_libevent() -> Option<Vec<String>> {
+    run_pkg_config()
+}
 
 fn main() {
-    // Use pkg-config to find and link libevent
-    pkg_config::Config::new()
-        .atleast_version("2")
-        .statik(cfg!(feature = "static"))
-        .probe("libevent")
-        .unwrap();
+    println!("cargo:rerun-if-changed=libevent");
+    println!("cargo:rerun-if-changed=wrapper.h");
 
-    let bindings = bindgen::Builder::default()
+    let target = env::var("TARGET").unwrap();
+    let host = env::var("HOST").unwrap();
+
+    let include_paths = find_libevent()
+        .expect("No include paths for libevent found");
+
+    let mut builder = bindgen::Builder::default();
+
+    if target != host {
+        builder = builder.clang_arg("-target");
+        builder = builder.clang_arg(target);
+    }
+
+    // Let bindgen know about all include paths that were found.
+    for path in include_paths {
+        builder = builder.clang_arg(format!("-I{}", path));
+    }
+
+    let bindings = builder
         .header("wrapper.h")
         // Enable for more readable bindings
         // .rustfmt_bindings(true)

--- a/libevent-sys/build.rs
+++ b/libevent-sys/build.rs
@@ -24,6 +24,11 @@ fn build_libevent(libevent_path: impl AsRef<std::path::Path>) -> PathBuf {
             .define("CMAKE_POLICY_DEFAULT_CMP0066", "NEW")*/
     }
 
+    // TODO: Can we tap into "-vv" cargo argument?
+    if cfg!(feature = "verbose_build") {
+        config.very_verbose(true);
+    }
+
     let dst = config.build();
 
     println!("cargo:rustc-link-search={}/lib", dst.display());
@@ -95,6 +100,14 @@ fn main() {
 
     let target = env::var("TARGET").unwrap();
     let host = env::var("HOST").unwrap();
+
+    if cfg!(feature = "verbose_build") {
+        for (key, val) in env::vars() {
+            println!("{}: {}", key, val);
+        }
+        let args: Vec<String> = env::args().collect();
+        println!("args: {:?}", args);
+    }
 
     let include_paths = find_libevent()
         .expect("No include paths for libevent found");

--- a/libevent-sys/wrapper.h
+++ b/libevent-sys/wrapper.h
@@ -1,1 +1,9 @@
 #include <event.h>
+
+#ifdef EVENT__HAVE_OPENSSL
+#include <event2/bufferevent_ssl.h>
+#endif
+
+#ifdef EVENT__HAVE_PTHREADS
+#include <event2/thread.h>
+#endif


### PR DESCRIPTION
Adds bundled source builds via CMake and the `bundled` feature flag. Also adds configuration for OpenSSL (`openssl`/`openssl_bundled`) and pthreads (`threading`).