### PR TITLE
Misc build-related fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,13 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [features]
-default = [ "openssl", "threading" ]
+default = [ "pkgconfig", "openssl", "threading" ]
 static = [ "libevent-sys/static" ]
+pkgconfig = [ "libevent-sys/pkgconfig" ]
 bundled = [ "static", "libevent-sys/bundled" ]
 openssl = [ "libevent-sys/openssl" ]
 openssl_bundled = [ "libevent-sys/openssl_bundled", "threading" ]
 threading = [ "libevent-sys/threading" ]
 
 [dependencies]
-libevent-sys = { version = "0.2", path = "libevent-sys" }
+libevent-sys = { version = "0.2", path = "libevent-sys", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,9 @@ openssl = [ "libevent-sys/openssl" ]
 openssl_bundled = [ "libevent-sys/openssl_bundled", "threading" ]
 threading = [ "libevent-sys/threading" ]
 
+# features for development
+verbose_build = [ "libevent-sys/verbose_build" ]
+
+
 [dependencies]
 libevent-sys = { version = "0.2", path = "libevent-sys", default-features = false }

--- a/libevent-sys/Cargo.toml
+++ b/libevent-sys/Cargo.toml
@@ -15,8 +15,9 @@ links = "event"
 build = "build.rs"
 
 [features]
-default = [ "pkg-config", "openssl", "threading" ]
+default = [ "pkgconfig", "openssl", "threading" ]
 static = []
+pkgconfig = [ "pkg-config" ]
 bundled = [ "static", "cmake" ]
 openssl = [ "openssl-sys" ]
 openssl_bundled = [ "openssl-sys/vendored", "threading" ]

--- a/libevent-sys/build.rs
+++ b/libevent-sys/build.rs
@@ -161,6 +161,10 @@ fn main() {
 
     let mut builder = bindgen::Builder::default();
 
+    if cfg!(feature = "verbose_build") {
+        builder = builder.clang_arg("-v");
+    }
+
     if target != host {
         // TODO: Is it necessary to specify target in clang_arg?
         // Ref: https://github.com/rust-lang/rust-bindgen/issues/1780

--- a/libevent-sys/build.rs
+++ b/libevent-sys/build.rs
@@ -162,8 +162,8 @@ fn main() {
     let mut builder = bindgen::Builder::default();
 
     if target != host {
-        builder = builder.clang_arg("-target");
-        builder = builder.clang_arg(target);
+        // TODO: Is it necessary to specify target in clang_arg?
+        // Ref: https://github.com/rust-lang/rust-bindgen/issues/1780
     }
 
     // Let bindgen know about all include paths that were found.

--- a/libevent-sys/build.rs
+++ b/libevent-sys/build.rs
@@ -30,6 +30,18 @@ fn build_libevent(libevent_path: impl AsRef<std::path::Path>) -> PathBuf {
         }
 
         config.register_dep("openssl");
+
+        let openssl_root = if let Ok(root) = env::var("DEP_OPENSSL_ROOT") {
+            root
+        } else {
+            let include_str = env::var("DEP_OPENSSL_INCLUDE").unwrap();
+            let include_dir = std::path::Path::new(&include_str);
+            let root_dir = format!("{}", include_dir.parent().unwrap().display());
+            env::set_var("DEP_OPENSSL_ROOT", &root_dir);
+            root_dir
+        };
+
+        config.define("OPENSSL_ROOT_DIR", openssl_root);
     } else {
         config.define("EVENT__DISABLE_OPENSSL", "ON");
     }


### PR DESCRIPTION
Fixes a few issues seen when cross-compiling, and also when building from OSX:

- Add feature flag `pkgconfig` to be able to re-enable pkg-config support when building with `default-features = false`.
- Remove setting target in `clang_arg` for bindgen. There were issues encountered when cross-compiling, and it gets discovered by bindgen internally, anyway. I still haven't looked into the code path discrepancies, but I suspect there might be an issue with not also setting the sysroot. TBD.
- Set and pass `OPENSSL_ROOT_DIR` into cmake when doing bundled builds. `FindOpenSSL.cmake` needs this.

Also included are some additions for verbose building.