### PR TITLE
release: prep libevent-sys 0.2.2

### DIFF
--- a/libevent-sys/Cargo.toml
+++ b/libevent-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libevent-sys"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Steven vanZyl <rushsteve1@rushsteve1.us>",
            "Jon Magnuson <jon.magnuson@gmail.com>"]
 repository = "https://github.com/jmagnuson/libevent-rs"

--- a/libevent-sys/LICENSE
+++ b/libevent-sys/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2018 Steven vanZyl
+Copyright (c) 2020 Jon Magnuson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/libevent-sys/README.md
+++ b/libevent-sys/README.md
@@ -2,19 +2,29 @@
 [![](https://meritbadge.herokuapp.com/libevent-sys)](https://crates.io/crates/libevent-sys)
 [![Released API docs](https://docs.rs/libevent-sys/badge.svg)](https://docs.rs/libevent-sys)
 
-Rust FFI bindings to [libevent](https://libevent.org/) library made using [Rust-Bindgen](https://github.com/rust-lang/rust-bindgen).
+Rust FFI bindings to [libevent] library made using [Rust-Bindgen].
 
-Created and maintained by the [Tornado Project](https://gitlab.com/tornado-torrent/)
+## System Requirements
 
-**Note this package only supports Linux at this time.**
+* `libclang` is required by [bindgen] which is used to generate the Rust
+  bindings. See [bindgen requirements] for more information. Also ensure that
+  `LIBCLANG_PATH` is set, as some systems do not do so by default.
 
-Support for MacOS and Windows is planned, but pull requests helping
-are greatly appreciated.
-Especially for MacOS because I do not have access to one.
+* `cmake` if self-building via the `bundled` feature. The current bundled
+  release is `release-2.1.11-stable`.
+
+* `pkg-config` if not self-building via the `bundled` feature.
+
 
 ## Building
 Depends on `libevent-dev` or equivalent to be installed on the system.
 It can be found in most distro's package managers or from the `libevent`
-website linked aboce.
+website linked above.
 
 Once that is installed just use `cargo build`.
+
+[libevent]: https://libevent.org/
+[Rust-Bindgen]: https://github.com/rust-lang/rust-bindgen
+[bindgen]: https://crates.io/crates/bindgen
+[bindgen requirements]: https://rust-lang.github.io/rust-bindgen/requirements.html
+


### PR DESCRIPTION
Append to license for new maintainer.

AFAICT it's not breaking since the default is still `pkg-config`, so only updating the patch.