### PR TITLE
libevent: add add_fd

### DIFF
--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -33,7 +33,7 @@ fn main() {
             .event_new(None, libevent::EventFlags::PERSIST, hello_callback, None)
     };
 
-    let _ = unsafe { libevent.base().event_add(&ev, Duration::from_secs(2)) };
+    let _ = unsafe { libevent.base().event_add(&ev, Some(Duration::from_secs(2))) };
 
     let mut a: usize = 0;
 

--- a/src/event/base.rs
+++ b/src/event/base.rs
@@ -158,11 +158,13 @@ impl EventBase {
         }
     }
 
-    pub fn event_add(&self, event: &EventHandle, timeout: Duration) -> c_int {
-        let tv = to_timeval(timeout);
+    pub fn event_add(&self, event: &EventHandle, timeout: Option<Duration>) -> c_int {
         unsafe {
             let p = event.inner.lock().unwrap().inner.unwrap().as_ptr();
-            libevent_sys::event_add(p, &tv)
+            libevent_sys::event_add(
+                p,
+                timeout.map_or_else(|| std::ptr::null(), |t| &to_timeval(t)),
+            )
         }
     }
 }

--- a/src/event/base.rs
+++ b/src/event/base.rs
@@ -4,6 +4,7 @@ use bitflags::bitflags;
 use libevent_sys;
 use std::io;
 use std::os::raw::{c_int, c_short, c_void};
+use std::ptr::NonNull;
 use std::time::Duration;
 
 use super::event::*;
@@ -22,35 +23,35 @@ fn to_timeval(duration: Duration) -> libevent_sys::timeval {
 }
 
 pub struct EventBase {
-    base: *mut libevent_sys::event_base,
+    base: NonNull<libevent_sys::event_base>,
 }
 
 /// The handle that abstracts over libevent's API in Rust.
 impl EventBase {
     pub fn new() -> Result<Self, io::Error> {
         let base = unsafe { libevent_sys::event_base_new() };
-
-        if base.is_null() {
-            return Err(io::Error::new(
+        if let Some(base) = NonNull::new(base) {
+            Ok(EventBase { base })
+        } else {
+            Err(io::Error::new(
                 io::ErrorKind::Other,
                 "Failed to create libevent base",
-            ));
+            ))
         }
-
-        Ok(EventBase { base })
     }
 
     pub fn as_inner(&self) -> *const libevent_sys::event_base {
-        self.base as *const libevent_sys::event_base
+        self.base.as_ptr() as *const libevent_sys::event_base
     }
 
     pub fn as_inner_mut(&mut self) -> *mut libevent_sys::event_base {
-        self.base
+        unsafe { self.base.as_mut() }
     }
 
     pub fn loop_(&self, flags: LoopFlags) -> ExitReason {
-        let exit_code =
-            unsafe { libevent_sys::event_base_loop(self.base, flags.bits() as i32) as i32 };
+        let exit_code = unsafe {
+            libevent_sys::event_base_loop(self.base.as_ptr(), flags.bits() as i32) as i32
+        };
 
         match exit_code {
             0 => {
@@ -58,9 +59,9 @@ impl EventBase {
                     // Technically mutually-exclusive from `got_break`, but
                     // the check in `event_base_loop` comes first, so the logic
                     // here matches.
-                    if libevent_sys::event_base_got_exit(self.base) != 0i32 {
+                    if libevent_sys::event_base_got_exit(self.base.as_ptr()) != 0i32 {
                         ExitReason::GotExit
-                    } else if libevent_sys::event_base_got_break(self.base) != 0i32 {
+                    } else if libevent_sys::event_base_got_break(self.base.as_ptr()) != 0i32 {
                         ExitReason::GotBreak
                     } else {
                         // TODO: This should match flags for `EVLOOP_ONCE`, `_NONBLOCK`, etc.
@@ -78,16 +79,16 @@ impl EventBase {
         let tv = to_timeval(timeout);
         unsafe {
             let tv_cast = &tv as *const libevent_sys::timeval;
-            libevent_sys::event_base_loopexit(self.base, tv_cast) as i32
+            libevent_sys::event_base_loopexit(self.base.as_ptr(), tv_cast) as i32
         }
     }
 
     pub fn loopbreak(&self) -> i32 {
-        unsafe { libevent_sys::event_base_loopbreak(self.base) as i32 }
+        unsafe { libevent_sys::event_base_loopbreak(self.base.as_ptr()) as i32 }
     }
 
     pub fn loopcontinue(&self) -> i32 {
-        unsafe { libevent_sys::event_base_loopcontinue(self.base) as i32 }
+        unsafe { libevent_sys::event_base_loopcontinue(self.base.as_ptr()) as i32 }
     }
 
     pub fn event_new(
@@ -168,6 +169,8 @@ impl EventBase {
         }
     }
 }
+
+unsafe impl Send for EventBase {}
 
 pub enum ExitReason {
     GotExit,

--- a/src/event/base.rs
+++ b/src/event/base.rs
@@ -30,6 +30,10 @@ pub struct EventBase {
 impl EventBase {
     pub fn new() -> Result<Self, io::Error> {
         let base = unsafe { libevent_sys::event_base_new() };
+        unsafe { Self::from_raw(base) }
+    }
+
+    pub unsafe fn from_raw(base: *mut libevent_sys::event_base) -> Result<Self, io::Error> {
         if let Some(base) = NonNull::new(base) {
             Ok(EventBase { base })
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,11 @@ impl Libevent {
         EventBase::new().map(|base| Libevent { base })
     }
 
+    pub unsafe fn from_raw(base: *mut libevent_sys::event_base) -> Result<Self, io::Error> {
+        let base = EventBase::from_raw(base)?;
+        Ok(Libevent { base })
+    }
+
     // TODO: This should be raw_base, and EventBase should prevent having to use raw altogether.
     /// # Safety
     /// Exposes the event_base handle, which can be used to make any sort of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 use libevent_sys;
 use std::io;
 use std::os::raw::{c_int, c_short};
+#[cfg(unix)]
+use std::os::unix::io::RawFd;
 use std::time::Duration;
 
 mod event;
@@ -125,7 +127,7 @@ impl Libevent {
             )
         };
 
-        let _ = unsafe { self.base().event_add(&ev, tv) };
+        let _ = unsafe { self.base().event_add(&ev, Some(tv)) };
 
         Ok(ev)
     }
@@ -142,5 +144,49 @@ impl Libevent {
         F: FnMut(&mut EventHandle, EventFlags) + 'static,
     {
         self.add_timer(timeout, cb, EventFlags::empty())
+    }
+
+    #[cfg(unix)]
+    pub fn add_fd<F>(&mut self, fd: RawFd, tv: Option<Duration>, cb: F) -> io::Result<EventHandle>
+    where
+        F: FnMut(&mut EventHandle, EventFlags) + 'static,
+    {
+        // First allocate the event with no context, then apply the reference
+        // to the closure (and itself) later on.
+        let mut ev = unsafe {
+            self.base_mut().event_new(
+                Some(fd),
+                EventFlags::PERSIST | EventFlags::READ,
+                handle_wrapped_callback,
+                None,
+            )
+        };
+
+        unsafe {
+            // A gross way to signify that we're leaking the boxed
+            // `EventCallbackWrapper` match libevent's context type.
+            // TODO: Use `event_finalize` to de-init boxed closure.
+            ev.inner.lock().unwrap().set_drop_ctx();
+        }
+
+        let cb_wrapped = Box::new(EventCallbackWrapper {
+            inner: Box::new(cb),
+            ev: ev.clone(),
+        });
+
+        // Now we can apply the closure + handle to self.
+        let _ = unsafe {
+            self.base_mut().event_assign(
+                &mut ev,
+                Some(fd),
+                EventFlags::PERSIST | EventFlags::READ,
+                handle_wrapped_callback,
+                Some(std::mem::transmute(cb_wrapped)),
+            )
+        };
+
+        let _ = unsafe { self.base().event_add(&ev, tv) };
+
+        Ok(ev)
     }
 }


### PR DESCRIPTION
Adds the ability to register a file descriptor with `Libevent` with an optional timeout value via `Libevent::add_fd`.  Additionally implements `Send` for `EventBase` and allows for obtaining an `EventBase` and `Libevent` from a raw pointer to a `libevent_sys::event_base`.