### PR TITLE
release: prep libevent-sys 0.2.3

### DIFF
--- a/libevent-sys/Cargo.toml
+++ b/libevent-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libevent-sys"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Steven vanZyl <rushsteve1@rushsteve1.us>",
            "Jon Magnuson <jon.magnuson@gmail.com>"]
 repository = "https://github.com/jmagnuson/libevent-rs"

--- a/libevent-sys/build.rs
+++ b/libevent-sys/build.rs
@@ -144,15 +144,13 @@ fn find_libevent() -> Option<Vec<String>> {
     use std::process::Command;
 
     if !Path::new("libevent/.git").exists() {
-        Command::new("git")
+        let _ = Command::new("git")
             .args(&["submodule", "update", "--init"])
-            .status()
-            .expect("Running `git submodule init` failed.");
+            .status();
     } else {
-        Command::new("git")
+        let _ = Command::new("git")
             .args(&["submodule", "update", "--recursive"])
-            .status()
-            .expect("Running `git submodule update` failed.");
+            .status();
     }
 
     Some(vec![format!(


### PR DESCRIPTION
This fixes an issue with bundled builds in 0.2.2, since cargo crates don't contain any git metadata to run `git submodule` on. I had also published without the actual source, so that will be included in 0.2.3.