### PR TITLE
build script: add buildtime_bindgen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,5 @@ script:
     # Now pkg-config build
   - sudo apt-get install -y libssl-dev libevent-dev
   - cargo clean
-  - cargo build --no-default-features --features "openssl,pkgconfig" # pkgconfig, openssl, threading
-  - cargo run --manifest-path examples/hello/Cargo.toml --no-default-features --features "openssl,pkgconfig" -- 5
+  - cargo build --no-default-features --features "openssl,pkgconfig,buildtime_bindgen" # pkgconfig, openssl, threading
+  - cargo run --manifest-path examples/hello/Cargo.toml --no-default-features --features "openssl,pkgconfig,buildtime_bindgen" -- 5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,11 @@ edition = "2018"
 members = ['examples/hello']
 
 [features]
-default = [ "pkgconfig", "openssl", "threading" ]
+default = [ "pkgconfig", "openssl", "threading", "buildtime_bindgen" ]
 static = [ "libevent-sys/static" ]
 pkgconfig = [ "libevent-sys/pkgconfig" ]
 bundled = [ "static", "libevent-sys/bundled" ]
+buildtime_bindgen = [ "libevent-sys/buildtime_bindgen" ]
 openssl = [ "libevent-sys/openssl" ]
 openssl_bundled = [ "libevent-sys/openssl_bundled", "threading" ]
 threading = [ "libevent-sys/threading" ]

--- a/examples/hello/Cargo.toml
+++ b/examples/hello/Cargo.toml
@@ -6,11 +6,12 @@ edition = "2018"
 build="build.rs"
 
 [features]
-default = [ "bundled", "openssl" ]
+default = [ "bundled", "openssl", "buildtime_bindgen" ]
 bundled = ["libevent/bundled",  "libevent-sys/bundled" ]
 openssl = ["libevent/openssl"]
 openssl_bundled = [ "libevent/openssl_bundled" ]
 pkgconfig = ["libevent/pkgconfig"]
+buildtime_bindgen = ["libevent/buildtime_bindgen"]
 
 [dependencies.libevent]
 path = "../../"

--- a/libevent-sys/Cargo.toml
+++ b/libevent-sys/Cargo.toml
@@ -15,10 +15,11 @@ links = "event"
 build = "build.rs"
 
 [features]
-default = [ "pkgconfig", "openssl", "threading" ]
+default = [ "pkgconfig", "openssl", "threading", "buildtime_bindgen" ]
 static = []
 pkgconfig = [ "pkg-config" ]
 bundled = [ "static", "cmake" ]
+buildtime_bindgen = [ "bindgen" ]
 openssl = [ "openssl-sys" ]
 openssl_bundled = [ "openssl-sys/vendored", "threading" ]
 threading = []
@@ -31,6 +32,6 @@ version = "0.9"
 optional = true
 
 [build-dependencies]
-bindgen = "0.53"
+bindgen = { version = "0.53", optional = true }
 cmake = { version = "0.1", optional = true }
 pkg-config = { version = "0.3", optional = true }


### PR DESCRIPTION
Add the ability to supply pregenerated libevent bindings via `LIBEVENT_SYS_BINDINGS_FILE` when the newly introduced `buildtime_bindgen` feature is not enabled.