### PR TITLE
Set MSRV to 1.35.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 language: rust
+os: linux
+dist: bionic
 rust:
   - 1.35.0 # msrv
   - stable
-
-jobs:
-  include:
-    - os: linux
-      dist: bionic
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: rust
 rust:
+  - 1.35.0 # msrv
   - stable
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ base.run();
   when `buildtime_bindgen` is not enabled, and it is only applicable in this
   case.
 
+## Minimum Supported Rust Version (MSRV)
+
+This crate is guaranteed to compile on stable Rust 1.35.0 and up. It might compile
+with older versions but that may change in any new patch release.
+
 ## License
 
 Licensed under either of


### PR DESCRIPTION
Using my super-scientific method of `rustup toolchain install`'ing until breakage, I found that [`Option::copied`](https://doc.rust-lang.org/std/option/enum.Option.html#method.copied) (used [here](https://github.com/jmagnuson/libevent-rs/blob/7829e6fa6afe57f99d2891f9a69ce40ca04bc7dc/src/event.rs#L181)) wasn't introduced until 1.35.0.

Closes #12