### PR TITLE
Add ability to inject a tokio runtime as the backend for libevent.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "libevent"
-version = "0.1.0"
-authors = ["Jon Magnuson <jon.magnuson@gmail.com>",
-           "Grant Elbert <elbe0046@gmail.com>"]
+version = "0.2.0"
+authors = [
+    "Jon Magnuson <jon.magnuson@gmail.com>",
+    "Grant Elbert <elbe0046@gmail.com>",
+    "Judge Maygarden <jmaygarden@gmail.com>",
+]
 description = "Rust bindings to the libevent async I/O framework"
 documentation = "https://docs.rs/libevent"
 repository = "https://github.com/jmagnuson/libevent-rs"
@@ -12,22 +15,37 @@ edition = "2018"
 categories = ["api-bindings", "asynchronous"]
 keywords = ["libevent", "bindings", "async", "io"]
 
+[lib]
+crate-type = ["lib", "staticlib"]
+
 [workspace]
 members = ['examples/hello']
 
 [features]
-default = [ "pkgconfig", "openssl", "threading", "buildtime_bindgen" ]
-static = [ "libevent-sys/static" ]
-pkgconfig = [ "libevent-sys/pkgconfig" ]
-bundled = [ "static", "libevent-sys/bundled" ]
-buildtime_bindgen = [ "libevent-sys/buildtime_bindgen" ]
-openssl = [ "libevent-sys/openssl" ]
-openssl_bundled = [ "libevent-sys/openssl_bundled", "threading" ]
-threading = [ "libevent-sys/threading" ]
+default = ["pkgconfig", "openssl", "threading", "buildtime_bindgen"]
+static = ["libevent-sys/static"]
+pkgconfig = ["libevent-sys/pkgconfig"]
+bundled = ["static", "libevent-sys/bundled"]
+buildtime_bindgen = ["libevent-sys/buildtime_bindgen"]
+openssl = ["libevent-sys/openssl"]
+openssl_bundled = ["libevent-sys/openssl_bundled", "threading"]
+threading = ["libevent-sys/threading"]
+tokio_backend = ["bundled", "libevent-sys/tokio_backend", "tokio"]
+tracing_subscriber = ["tracing-subscriber"]
 
 # features for development
-verbose_build = [ "libevent-sys/verbose_build" ]
+verbose_build = ["libevent-sys/verbose_build"]
 
 [dependencies]
 bitflags = "1.2"
-libevent-sys = { version = "0.2", path = "libevent-sys", default-features = false }
+libevent-sys = { version = "0.3", path = "libevent-sys", default-features = false }
+tokio = { version = "1", optional = true, features = [
+    "macros",
+    "net",
+    "rt",
+    "signal",
+    "sync",
+    "time",
+] }
+tracing = { version = "0.1" }
+tracing-subscriber = { version = "0.2", optional = true }

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+CFLAGS = -Wall -Werror
+SAMPLE_DIR = sample
+OUT_DIR = target/debug
+LIBS = \
+	-L$(OUT_DIR) \
+	-llibevent
+SAMPLES_SRC = \
+	$(SAMPLE_DIR)/dns-example.c \
+	$(SAMPLE_DIR)/event-read-fifo.c \
+	$(SAMPLE_DIR)/hello-world.c \
+	$(SAMPLE_DIR)/time-test.c
+SAMPLES_BIN = $(patsubst %.c,%,$(SAMPLES_SRC))
+
+all: $(SAMPLES_BIN)
+
+%: %.c $(OUT_DIR)/liblibevent.a
+	$(CC) $(CFLAGS) -o $@ $(LIBS) $<
+
+$(OUT_DIR)/liblibevent.a: FORCE
+	RUSTFLAGS="--cfg tokio_unstable" cargo build --features tracing_subscriber,tokio_backend
+
+run-hello-world: $(SAMPLE_DIR)/hello-world
+	RUST_BACKTRACE=1 RUST_LOG=debug ./$<
+
+FORCE: ;
+
+clean:
+	$(RM) $(SAMPLES_BIN)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,23 @@ base.run();
   when `buildtime_bindgen` is not enabled, and it is only applicable in this
   case.
 
+## Tokio Backend for libevent
+
+A optional tokio backend for handling libevent I/O and signal readiness is
+optionally provided. It is not patched into libevent directly, but is
+substituted at run time with a call to `libevent::inject_tokio`. The primary
+motivation for this feature is to allow native tokio and libevent tasks to
+co-exist with a single event loop on the same thread. This feature is
+especially useful when gradually migrating a C/libevent project to Rust/tokio
+when use of FFI between the C and Rust code prevents running the event loops
+on separate threads.
+
+## Samples
+
+Versions of libevent samples modified to make use of an injected tokio
+backend are located in the ./sample directory. There is a Makefile provided
+for building these C programs linked to the Rust libevent crate.
+
 ## Minimum Supported Rust Version (MSRV)
 
 This crate is guaranteed to compile on stable Rust 1.35.0 and up. It might compile

--- a/examples/hello/Cargo.toml
+++ b/examples/hello/Cargo.toml
@@ -1,17 +1,32 @@
 [package]
 name = "hello"
 version = "0.1.0"
-authors = ["Jon Magnuson <jon.magnuson@gmail.com>"]
+authors = [
+    "Jon Magnuson <jon.magnuson@gmail.com>",
+    "Judge Maygarden <jmaygarden@gmail.com>",
+]
 edition = "2018"
-build="build.rs"
+build = "build.rs"
 
 [features]
-default = [ "bundled", "openssl", "buildtime_bindgen" ]
-bundled = ["libevent/bundled",  "libevent-sys/bundled" ]
+default = [
+    "bundled",
+    "openssl",
+    "buildtime_bindgen",
+    "tokio_backend",
+    "tracing_subscriber",
+]
+bundled = ["libevent/bundled", "libevent-sys/bundled"]
 openssl = ["libevent/openssl"]
-openssl_bundled = [ "libevent/openssl_bundled" ]
+openssl_bundled = ["libevent/openssl_bundled"]
 pkgconfig = ["libevent/pkgconfig"]
 buildtime_bindgen = ["libevent/buildtime_bindgen"]
+tokio_backend = ["libevent/tokio_backend", "tokio"]
+tracing_subscriber = ["tracing-subscriber"]
+
+[dependencies]
+tokio = { version = "1", optional = true, features = ["rt"] }
+tracing-subscriber = { version = "0.2", optional = true }
 
 [dependencies.libevent]
 path = "../../"

--- a/libevent-sys/Cargo.toml
+++ b/libevent-sys/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "libevent-sys"
-version = "0.2.4"
-authors = ["Steven vanZyl <rushsteve1@rushsteve1.us>",
-           "Jon Magnuson <jon.magnuson@gmail.com>",
-           "Grant Elbert <elbe0046@gmail.com>"]
+version = "0.3.0"
+authors = [
+    "Steven vanZyl <rushsteve1@rushsteve1.us>",
+    "Jon Magnuson <jon.magnuson@gmail.com>",
+    "Grant Elbert <elbe0046@gmail.com>",
+    "Judge Maygarden <jmaygarden@gmail.com>",
+]
 repository = "https://github.com/jmagnuson/libevent-rs"
 edition = "2018"
 readme = "README.md"
@@ -16,14 +19,15 @@ links = "event"
 build = "build.rs"
 
 [features]
-default = [ "pkgconfig", "openssl", "threading", "buildtime_bindgen" ]
+default = ["pkgconfig", "openssl", "threading", "buildtime_bindgen"]
 static = []
-pkgconfig = [ "pkg-config" ]
-bundled = [ "static", "cmake" ]
-buildtime_bindgen = [ "bindgen" ]
-openssl = [ "openssl-sys" ]
-openssl_bundled = [ "openssl-sys/vendored", "threading" ]
+pkgconfig = ["pkg-config"]
+bundled = ["static", "cmake"]
+buildtime_bindgen = ["bindgen"]
+openssl = ["openssl-sys"]
+openssl_bundled = ["openssl-sys/vendored", "threading"]
 threading = []
+tokio_backend = ["bundled", "buildtime_bindgen"]
 
 # features for development
 verbose_build = []
@@ -33,6 +37,6 @@ version = "0.9"
 optional = true
 
 [build-dependencies]
-bindgen = { version = "0.53", optional = true }
+bindgen = { version = "0.59", optional = true }
 cmake = { version = "0.1", optional = true }
 pkg-config = { version = "0.3", optional = true }

--- a/sample/hello-world.c
+++ b/sample/hello-world.c
@@ -1,0 +1,143 @@
+/*
+  This example program provides a trivial server program that listens for TCP
+  connections on port 9995.  When they arrive, it writes a short message to
+  each client connection, and closes each connection once it is flushed.
+
+  Where possible, it exits cleanly in response to a SIGINT (ctrl-c).
+*/
+
+
+#include <string.h>
+#include <errno.h>
+#include <stdio.h>
+#include <signal.h>
+#ifndef _WIN32
+#include <netinet/in.h>
+# ifdef _XOPEN_SOURCE_EXTENDED
+#  include <arpa/inet.h>
+# endif
+#include <sys/socket.h>
+#endif
+
+#include <event2/bufferevent.h>
+#include <event2/buffer.h>
+#include <event2/listener.h>
+#include <event2/util.h>
+#include <event2/event.h>
+
+#include "tokio_event_base.h"
+
+static const char MESSAGE[] = "Hello, World!\n";
+
+static const int PORT = 9995;
+
+static void listener_cb(struct evconnlistener *, evutil_socket_t,
+    struct sockaddr *, int socklen, void *);
+static void conn_writecb(struct bufferevent *, void *);
+static void conn_eventcb(struct bufferevent *, short, void *);
+static void signal_cb(evutil_socket_t, short, void *);
+
+int
+main(int argc, char **argv)
+{
+	struct event_base *base;
+	struct evconnlistener *listener;
+	struct event *signal_event;
+
+	struct sockaddr_in sin;
+#ifdef _WIN32
+	WSADATA wsa_data;
+	WSAStartup(0x0201, &wsa_data);
+#endif
+
+	base = tokio_event_base_new();
+	if (!base) {
+		fprintf(stderr, "Could not initialize libevent!\n");
+		return 1;
+	}
+
+	memset(&sin, 0, sizeof(sin));
+	sin.sin_family = AF_INET;
+	sin.sin_port = htons(PORT);
+
+	listener = evconnlistener_new_bind(base, listener_cb, (void *)base,
+	    LEV_OPT_REUSEABLE|LEV_OPT_CLOSE_ON_FREE, -1,
+	    (struct sockaddr*)&sin,
+	    sizeof(sin));
+
+	if (!listener) {
+		fprintf(stderr, "Could not create a listener!\n");
+		return 1;
+	}
+
+	signal_event = evsignal_new(base, SIGINT, signal_cb, (void *)base);
+
+	if (!signal_event || event_add(signal_event, NULL)<0) {
+		fprintf(stderr, "Could not create/add a signal event!\n");
+		return 1;
+	}
+
+	event_base_dispatch(base);
+
+	evconnlistener_free(listener);
+	event_free(signal_event);
+	event_base_free(base);
+
+	printf("done\n");
+	return 0;
+}
+
+static void
+listener_cb(struct evconnlistener *listener, evutil_socket_t fd,
+    struct sockaddr *sa, int socklen, void *user_data)
+{
+	struct event_base *base = user_data;
+	struct bufferevent *bev;
+
+	bev = bufferevent_socket_new(base, fd, BEV_OPT_CLOSE_ON_FREE);
+	if (!bev) {
+		fprintf(stderr, "Error constructing bufferevent!");
+		event_base_loopbreak(base);
+		return;
+	}
+	bufferevent_setcb(bev, NULL, conn_writecb, conn_eventcb, NULL);
+	bufferevent_enable(bev, EV_WRITE);
+	bufferevent_disable(bev, EV_READ);
+
+	bufferevent_write(bev, MESSAGE, strlen(MESSAGE));
+}
+
+static void
+conn_writecb(struct bufferevent *bev, void *user_data)
+{
+	struct evbuffer *output = bufferevent_get_output(bev);
+	if (evbuffer_get_length(output) == 0) {
+		printf("flushed answer\n");
+		bufferevent_free(bev);
+	}
+}
+
+static void
+conn_eventcb(struct bufferevent *bev, short events, void *user_data)
+{
+	if (events & BEV_EVENT_EOF) {
+		printf("Connection closed.\n");
+	} else if (events & BEV_EVENT_ERROR) {
+		printf("Got an error on the connection: %s\n",
+		    strerror(errno));/*XXX win32*/
+	}
+	/* None of the other events can happen here, since we haven't enabled
+	 * timeouts */
+	bufferevent_free(bev);
+}
+
+static void
+signal_cb(evutil_socket_t sig, short events, void *user_data)
+{
+	struct event_base *base = user_data;
+	struct timeval delay = { 2, 0 };
+
+	printf("Caught an interrupt signal; exiting cleanly in two seconds.\n");
+
+	event_base_loopexit(base, &delay);
+}

--- a/sample/time-test.c
+++ b/sample/time-test.c
@@ -1,0 +1,112 @@
+/*
+ * XXX This sample code was once meant to show how to use the basic Libevent
+ * interfaces, but it never worked on non-Unix platforms, and some of the
+ * interfaces have changed since it was first written.  It should probably
+ * be removed or replaced with something better.
+ *
+ * Compile with:
+ * cc -I/usr/local/include -o time-test time-test.c -L/usr/local/lib -levent
+ */
+
+#include <sys/types.h>
+
+#include <event2/event-config.h>
+
+#include <sys/stat.h>
+#ifndef _WIN32
+#include <sys/queue.h>
+#include <unistd.h>
+#endif
+#include <time.h>
+#ifdef EVENT__HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif
+#include <fcntl.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+
+#include <event2/event.h>
+#include <event2/event_struct.h>
+#include <event2/util.h>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#endif
+
+#include "tokio_event_base.h"
+
+struct timeval lasttime;
+
+int event_is_persistent;
+
+static void
+timeout_cb(evutil_socket_t fd, short event, void *arg)
+{
+	struct timeval newtime, difference;
+	struct event *timeout = arg;
+	double elapsed;
+
+	evutil_gettimeofday(&newtime, NULL);
+	evutil_timersub(&newtime, &lasttime, &difference);
+	elapsed = difference.tv_sec +
+	    (difference.tv_usec / 1.0e6);
+
+	printf("timeout_cb called at %d: %.3f seconds elapsed.\n",
+	    (int)newtime.tv_sec, elapsed);
+	lasttime = newtime;
+
+	if (! event_is_persistent) {
+		struct timeval tv;
+		evutil_timerclear(&tv);
+		tv.tv_sec = 2;
+		event_add(timeout, &tv);
+	}
+}
+
+int
+main(int argc, char **argv)
+{
+	struct event timeout;
+	struct timeval tv;
+	struct event_base *base;
+	int flags;
+
+#ifdef _WIN32
+	WORD wVersionRequested;
+	WSADATA wsaData;
+
+	wVersionRequested = MAKEWORD(2, 2);
+
+	(void)WSAStartup(wVersionRequested, &wsaData);
+#endif
+
+	if (argc == 2 && !strcmp(argv[1], "-p")) {
+		event_is_persistent = 1;
+		flags = EV_PERSIST;
+	} else {
+		event_is_persistent = 0;
+		flags = 0;
+	}
+
+	/* Initalize the event library */
+	base = tokio_event_base_new();
+
+	/* Initalize one event */
+	event_assign(&timeout, base, -1, flags, timeout_cb, (void*) &timeout);
+
+	evutil_timerclear(&tv);
+	tv.tv_sec = 2;
+	event_add(&timeout, &tv);
+
+	evutil_gettimeofday(&lasttime, NULL);
+
+	setbuf(stdout, NULL);
+	setbuf(stderr, NULL);
+
+	event_base_dispatch(base);
+
+	return (0);
+}
+

--- a/sample/tokio_event_base.h
+++ b/sample/tokio_event_base.h
@@ -1,0 +1,7 @@
+#pragma once
+
+/*
+ * Creates a new event_base and injects a single-threaded tokio runtime into
+ * it as the backend.
+ */
+extern struct event_base* tokio_event_base_new(void);

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,0 +1,465 @@
+use std::{
+    collections::HashMap,
+    ffi::c_void,
+    os::raw::{c_int, c_short},
+    ptr::NonNull,
+    sync::Arc,
+    time::Duration,
+};
+use tokio::{
+    io::unix::AsyncFd,
+    signal::unix::{signal, SignalKind},
+    sync::Notify,
+};
+use tracing::instrument;
+
+/// Implements a libevent backend using a tokio runtime
+#[derive(Debug)]
+pub struct TokioBackend {
+    /// Callback functions and configuration for I/O handling
+    evsel: libevent_sys::eventop,
+    /// Callback functions and configuration for signal handling
+    evsigsel: libevent_sys::eventop,
+    /// Tokio runtime for driving I/O and signal events
+    runtime: tokio::runtime::Runtime,
+    /// Map of active signals to task shutdown notifications
+    signal_map: HashMap<c_int, Arc<Notify>>,
+}
+
+impl TokioBackend {
+    /// Create a new tokio libevent backend using the provided runtime
+    #[instrument]
+    fn new(runtime: tokio::runtime::Runtime) -> Self {
+        const EVSEL: libevent_sys::eventop = libevent_sys::eventop {
+            name: "tokio".as_ptr().cast(),
+            init: Some(tokio_backend_init),
+            add: Some(tokio_backend_add),
+            del: Some(tokio_backend_del),
+            dispatch: Some(tokio_backend_dispatch),
+            dealloc: Some(tokio_backend_dealloc),
+            need_reinit: 1,
+            features: libevent_sys::event_method_feature_EV_FEATURE_FDS,
+            fdinfo_len: std::mem::size_of::<Arc<Notify>>() as u64,
+        };
+        const EVSIGSEL: libevent_sys::eventop = libevent_sys::eventop {
+            name: "tokio_signal".as_ptr().cast(),
+            init: None,
+            add: Some(tokio_signal_backend_add),
+            del: Some(tokio_signal_backend_del),
+            dispatch: None,
+            dealloc: None,
+            need_reinit: 0,
+            features: 0,
+            fdinfo_len: 0,
+        };
+        let signal_map = HashMap::new();
+
+        Self {
+            evsel: EVSEL,
+            evsigsel: EVSIGSEL,
+            runtime,
+            signal_map,
+        }
+    }
+
+    /// Creates a task to service a libevent I/O request
+    ///
+    /// A task must continue to service the file descriptor events until
+    /// explicitly removed. Space is allocated by libevent that is used
+    /// to store an Arc<Notify> object for clean shutdown of the created
+    /// task.
+    ///
+    /// AsyncFd is used to assess read and write readiness of the
+    /// file descriptor. All higher level funcitonality like socket listening
+    /// and DNS request rely on these readiness notifications, but they
+    /// otherwise function using unchanged libevent code.
+    #[instrument(skip(base))]
+    fn add_io(
+        &self,
+        base: *mut libevent_sys::event_base,
+        fd: c_int,
+        events: c_short,
+        fdinfo: *mut Arc<Notify>,
+    ) -> c_int {
+        tracing::debug!("add an I/O event");
+
+        // signal events should never be passed to this function
+        assert_eq!(event_is_signal(events), false);
+
+        let base = BaseWrapper(base as *mut libevent_sys::event_base);
+        let is_read = event_is_read(events);
+        let is_write = event_is_write(events);
+        let _guard = self.runtime.enter();
+
+        match AsyncFd::new(fd) {
+            Ok(async_fd) => {
+                // The Arc<Notify> is cloned and copied into the allocated space
+                // for the file descriptor. The object is no longer guarded and
+                // must be dropped manually when the I/O event is deleted.
+                let notify = Arc::new(Notify::new());
+                unsafe {
+                    fdinfo.write(notify.clone());
+                }
+
+                // A tokio task is spawned to service each I/O event.
+                self.runtime.spawn(async move {
+                    loop {
+                        tokio::select! {
+                            result = async_fd.readable(), if is_read => {
+                                match result {
+                                    Ok(mut guard) => {
+                                        tracing::debug!(fd, "I/O ready to read");
+                                        unsafe {
+                                            // libevent dispatches the callback mapped to the file descriptor.
+                                            libevent_sys::evmap_io_active_(base.0, fd, libevent_sys::EV_READ as i16);
+                                        }
+
+                                        // If the ready flag is not cleared, then this loop will hang the runtime.
+                                        guard.clear_ready();
+                                    }
+                                    Err(error) => {
+                                        tracing::error!(?error);
+                                        break;
+                                    }
+                                }
+                            },
+                            result = async_fd.writable(), if is_write => {
+                                match result {
+                                    Ok(mut guard) => {
+                                        tracing::debug!(fd, "I/O ready to write");
+                                        unsafe {
+                                            // libevent dispatches the callback with the mapped file descriptor
+                                            libevent_sys::evmap_io_active_(base.0, fd, libevent_sys::EV_WRITE as i16);
+                                        }
+
+                                        // If the ready flag is not cleared, then this loop will hang the runtime.
+                                        guard.clear_ready();
+                                    }
+                                    Err(error) => {
+                                        tracing::error!(?error);
+                                        break;
+                                    }
+                                }
+                            },
+                            _ = notify.notified() => break, // terminate the task on notification
+                        }
+                    }
+
+                    tracing::debug!(?fd, "I/O task terminated");
+                });
+
+                0
+            }
+            Err(error) => {
+                tracing::error!(?error);
+                -1
+            }
+        }
+    }
+
+    /// Terminates an active I/O task
+    #[instrument]
+    fn del_io(&self, fdinfo: *mut Arc<Notify>) -> c_int {
+        tracing::debug!("delete an I/O event");
+
+        unsafe {
+            match fdinfo.as_mut() {
+                Some(notify) => {
+                    notify.notify_one();
+                    std::ptr::drop_in_place(fdinfo);
+                    0
+                }
+                None => -1,
+            }
+        }
+    }
+
+    /// Drive the tokio runtime with an optional duration for timout events
+    #[instrument]
+    fn dispatch(&self, timeout: Option<Duration>) {
+        self.runtime.block_on(async move {
+            match timeout {
+                // spawned tasks are serviced during the sleep time
+                Some(timeout) => tokio::time::sleep(timeout).await,
+                // at least a single yield is required to advance any pending tasks
+                None => tokio::task::yield_now().await,
+            }
+        })
+    }
+
+    /// Creates a task to service a libevent signal request
+    ///
+    /// A task must continue to provide signal notifications until explicitly
+    /// removed. Note that libevent does not provide user data per signal
+    /// event. Therefore, signals are mapped to notifications in TokioBackend
+    /// to allow for clean task shutdown.
+    ///
+    /// Since the tokio signal handler is installed globally. It is safe to
+    /// handle signals with both libevent and using tokio directly.
+    #[instrument(skip(base))]
+    fn add_signal(
+        &mut self,
+        base: *mut libevent_sys::event_base,
+        nsignal: c_int,
+        events: c_short,
+    ) -> c_int {
+        let base = BaseWrapper(base as *mut libevent_sys::event_base);
+
+        tracing::debug!("add a signal event");
+
+        // I/O events should never be passed to this function
+        assert!(event_is_signal(events));
+
+        let _guard = self.runtime.enter();
+
+        match signal(SignalKind::from_raw(nsignal)) {
+            Ok(mut stream) => {
+                // map a shutdown notification to the signal number
+                let notify = Arc::new(Notify::new());
+                if let Some(old_notify) = self.signal_map.insert(nsignal, notify.clone()) {
+                    /*
+                     * This should not happend since libevent tracks signal
+                     * registration. However, any previous task should be
+                     * shutdown to ensure that it does not leak.
+                     */
+                    old_notify.notify_one();
+                }
+
+                // a tokio task is spawned per signal number
+                self.runtime.spawn(async move {
+                    loop {
+                        tokio::select! {
+                            result = stream.recv() => {
+                                if result.is_some() {
+                                    tracing::debug!(nsignal, "signal received");
+                                    unsafe {
+                                        // libevent dispatches callbacks with the mapped signal
+                                        libevent_sys::evmap_signal_active_(base.0, nsignal, 1);
+                                    }
+                                } else {
+                                    tracing::error!("signal stream has closed");
+                                    break;
+                                }
+                            },
+                            _ = notify.notified() => break, // terminate the task on notification
+                        }
+                    }
+
+                    // indicate that the task has terminated
+                    tracing::debug!(?nsignal, "I/O task terminated");
+                });
+
+                0
+            }
+            Err(error) => {
+                tracing::error!(?error);
+                -1
+            }
+        }
+    }
+
+    /// Terminates an active signal task
+    #[instrument]
+    fn del_signal(&mut self, nsignal: c_int) -> c_int {
+        tracing::debug!("delete an signal event");
+
+        match self.signal_map.remove(&nsignal) {
+            Some(notify) => {
+                notify.notify_one();
+                0
+            }
+            None => {
+                tracing::warn!("signal not found");
+                -1
+            }
+        }
+    }
+}
+
+/// Wrapper to allow sending of raw event_base pointers to tokio tasks.
+///
+/// This is safe because libevent performs locking internally.
+struct BaseWrapper(pub *mut libevent_sys::event_base);
+
+unsafe impl Send for BaseWrapper {}
+
+/// Injects a tokio backend with the given runtime into the given libevent instance.
+///
+/// The libevent instance will already have an initialized backend. This
+/// exisiting backend is deallocated before being replaced.
+///
+/// A tracing-subscriber may also be initialized if the feature is activated
+/// to enable tracing output when linked to a C program.
+pub fn inject_tokio(mut base: NonNull<libevent_sys::event_base>, runtime: tokio::runtime::Runtime) {
+    #[cfg(feature = "tracing_subscriber")]
+    tracing_subscriber::fmt::init();
+
+    let backend = Box::new(TokioBackend::new(runtime));
+    let base = unsafe { base.as_mut() };
+
+    if let Some(evsel) = unsafe { base.evsel.as_ref() } {
+        if let Some(dealloc) = evsel.dealloc {
+            unsafe {
+                dealloc(base);
+            }
+        }
+    }
+
+    base.evsel = &backend.evsel;
+    base.evsigsel = &backend.evsigsel;
+    base.evbase = Box::into_raw(backend).cast();
+}
+
+/// Convenience function that returns true if the signal event bit is set.
+fn event_is_signal(events: c_short) -> bool {
+    let events = events as u32;
+
+    events & libevent_sys::EV_SIGNAL != 0
+}
+
+/// Convenience function that returns true if the I/O read event bit is set.
+fn event_is_read(events: c_short) -> bool {
+    let events = events as u32;
+
+    events & libevent_sys::EV_READ != 0
+}
+
+/// Convenience function that returns true if the I/O write event bit is set.
+fn event_is_write(events: c_short) -> bool {
+    let events = events as u32;
+
+    events & libevent_sys::EV_WRITE != 0
+}
+
+/// Convenience method to allow injecting C programs with a tokio backend
+#[no_mangle]
+pub unsafe extern "C" fn tokio_event_base_new() -> *mut libevent_sys::event_base {
+    let base = NonNull::new(libevent_sys::event_base_new());
+
+    match base {
+        Some(base) => {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("failed to build a tokio runtime");
+
+            inject_tokio(base, runtime);
+
+            base.as_ptr()
+        }
+        None => std::ptr::null_mut(),
+    }
+}
+
+/// libevent callback to initialize the backend
+///
+/// This function would normally be called in `event_base_new`, but the tokio
+/// backend is inject after that call. Therefore, this call would only happen
+/// if the process is forked. That functionality is not currently supported.
+#[no_mangle]
+pub unsafe extern "C" fn tokio_backend_init(_base: *mut libevent_sys::event_base) -> *mut c_void {
+    unimplemented!("forking with a tokio backend")
+}
+
+/// libevent callback to add an I/O event
+#[no_mangle]
+pub unsafe extern "C" fn tokio_backend_add(
+    eb: *mut libevent_sys::event_base,
+    fd: c_int,
+    _old: c_short,
+    events: c_short,
+    fdinfo: *mut c_void,
+) -> c_int {
+    if let Some(base) = eb.as_ref() {
+        if let Some(backend) = (base.evbase as *mut TokioBackend).as_ref() {
+            return backend.add_io(eb, fd, events, fdinfo.cast());
+        }
+    }
+
+    -1
+}
+
+/// libevent callback to remove an I/O event
+#[no_mangle]
+unsafe extern "C" fn tokio_backend_del(
+    base: *mut libevent_sys::event_base,
+    _fd: c_int,
+    _old: c_short,
+    _events: c_short,
+    fdinfo: *mut c_void,
+) -> c_int {
+    if let Some(base) = base.as_ref() {
+        if let Some(backend) = (base.evbase as *mut TokioBackend).as_ref() {
+            return backend.del_io(fdinfo.cast());
+        }
+    }
+
+    -1
+}
+
+/// libevent callback to drive the event loop
+#[no_mangle]
+unsafe extern "C" fn tokio_backend_dispatch(
+    base: *mut libevent_sys::event_base,
+    tv: *mut libevent_sys::timeval,
+) -> c_int {
+    if let Some(base) = base.as_ref() {
+        if let Some(backend) = (base.evbase as *mut TokioBackend).as_ref() {
+            let timeout = tv.as_ref().map(|tv| {
+                Duration::from_secs(tv.tv_sec as u64)
+                    .saturating_add(Duration::from_micros(tv.tv_usec as u64))
+            });
+
+            backend.dispatch(timeout);
+
+            return 0;
+        }
+    }
+
+    -1
+}
+
+/// libevent callback to deallocate the backend
+#[no_mangle]
+pub unsafe extern "C" fn tokio_backend_dealloc(base: *mut libevent_sys::event_base) {
+    if let Some(base) = base.as_mut() {
+        Box::from_raw(base.evbase);
+        base.evbase = std::ptr::null_mut();
+    }
+}
+
+/// libevent callback to add a signal event
+#[no_mangle]
+pub unsafe extern "C" fn tokio_signal_backend_add(
+    eb: *mut libevent_sys::event_base,
+    fd: c_int,
+    _old: c_short,
+    events: c_short,
+    _fdinfo: *mut c_void,
+) -> c_int {
+    if let Some(base) = eb.as_ref() {
+        if let Some(backend) = (base.evbase as *mut TokioBackend).as_mut() {
+            return backend.add_signal(eb, fd, events);
+        }
+    }
+
+    -1
+}
+
+/// libevent callback to remove a signal event
+#[no_mangle]
+unsafe extern "C" fn tokio_signal_backend_del(
+    base: *mut libevent_sys::event_base,
+    fd: c_int,
+    _old: c_short,
+    _events: c_short,
+    _fdinfo: *mut c_void,
+) -> c_int {
+    if let Some(base) = base.as_ref() {
+        if let Some(backend) = (base.evbase as *mut TokioBackend).as_mut() {
+            return backend.del_signal(fd);
+        }
+    }
+
+    -1
+}

--- a/src/base.rs
+++ b/src/base.rs
@@ -51,6 +51,12 @@ impl Base {
         }
     }
 
+    /// Replaces the standard libevent backend with tokio
+    #[cfg(feature = "tokio_backend")]
+    pub fn inject_tokio(&self, runtime: tokio::runtime::Runtime) {
+        super::backend::inject_tokio(self.base, runtime)
+    }
+
     /// Creates a new instance of `Base` using a raw, non-null `event_base`
     /// pointer.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,9 @@ pub use base::{
     Base, EventCallbackCtx, EventCallbackFlags, EventFlags, EvutilSocket, ExitReason, LoopFlags,
 };
 
+#[cfg(feature = "tokio_backend")]
+mod backend;
+
 /// The context passed into `handle_wrapped_callback`, which handles event-type
 /// specific metadata for trampolining into the user-supplied closure.
 pub(crate) struct EventCallbackWrapper<S, T, F> {


### PR DESCRIPTION
A optional tokio backend for handling libevent I/O and signal readiness is optionally provided. It is not patched into libevent directly, but is substituted at run time with a call to `libevent::inject_tokio`.

The primary motivation for this feature is to allow native tokio and libevent tasks to co-exist with a single event loop on the same thread. This feature is especially useful when gradually migrating a C/libevent project to Rust/tokio when use of FFI between the C and Rust code prevents running the event loops on separate threads.

The feature requires bundling of the libevent C code build with libevent-sys due to dependencies on internal/non-public data structures within the library. It could work with a system installed build of libevent if the versions match, but that approach would not be without risk.