### PR TITLE
libevent-sys: bump bundled libevent to 2.1.12-stable

### DIFF
--- a/libevent-sys/Cargo.toml
+++ b/libevent-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libevent-sys"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Steven vanZyl <rushsteve1@rushsteve1.us>",
            "Jon Magnuson <jon.magnuson@gmail.com>",
            "Grant Elbert <elbe0046@gmail.com>"]

--- a/libevent-sys/README.md
+++ b/libevent-sys/README.md
@@ -12,7 +12,7 @@ Rust FFI bindings to [libevent] library made using [Rust-Bindgen].
   is only required if `buildtime_bindgen` is enabled.
 
 * `cmake` if self-building via the `bundled` feature. The current bundled
-  release is `release-2.1.11-stable`.
+  release is `release-2.1.12-stable`.
 
 * `pkg-config` if not self-building via the `bundled` feature.
 


### PR DESCRIPTION
https://github.com/libevent/libevent/releases/tag/release-2.1.12-stable