### PR TITLE
Update bindgen

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         os: [ubuntu-latest]
         rust:
           - stable
-          - 1.56 # msrv
+          - 1.57 # msrv
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         os: [ubuntu-latest]
         rust:
           - stable
-          - 1.54 # msrv
+          - 1.56 # msrv
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         os: [ubuntu-latest]
         rust:
           - stable
-          - 1.47 # msrv
+          - 1.54 # msrv
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/libevent"
 repository = "https://github.com/jmagnuson/libevent-rs"
 readme = "README.md"
 license = "MIT/Apache-2.0"
-edition = "2018"
+edition = "2021"
 categories = ["api-bindings", "asynchronous"]
 keywords = ["libevent", "bindings", "async", "io"]
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ base.run();
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.47.0 and up. It might compile
+This crate is guaranteed to compile on stable Rust 1.54.0 and up. It might compile
 with older versions but that may change in any new patch release.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ base.run();
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.54.0 and up. It might compile
+This crate is guaranteed to compile on stable Rust 1.56.0 and up. It might compile
 with older versions but that may change in any new patch release.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ base.run();
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.56.0 and up. It might compile
+This crate is guaranteed to compile on stable Rust 1.57.0 and up. It might compile
 with older versions but that may change in any new patch release.
 
 ## License

--- a/libevent-sys/Cargo.toml
+++ b/libevent-sys/Cargo.toml
@@ -33,6 +33,6 @@ version = "0.9"
 optional = true
 
 [build-dependencies]
-bindgen = { version = "0.53", optional = true }
+bindgen = { version = "0.60", optional = true }
 cmake = { version = "0.1", optional = true }
 pkg-config = { version = "0.3", optional = true }

--- a/libevent-sys/Cargo.toml
+++ b/libevent-sys/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Steven vanZyl <rushsteve1@rushsteve1.us>",
            "Jon Magnuson <jon.magnuson@gmail.com>",
            "Grant Elbert <elbe0046@gmail.com>"]
 repository = "https://github.com/jmagnuson/libevent-rs"
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 license = "MIT"
 description = "Rust FFI bindings to the libevent library"

--- a/libevent-sys/build.rs
+++ b/libevent-sys/build.rs
@@ -193,7 +193,7 @@ fn generate_bindings(include_paths: Vec<String>, out_path: impl AsRef<Path>) {
         // Enable for more readable bindings
         // .rustfmt_bindings(true)
         // Fixes a bug with a duplicated const
-        .blacklist_item("IPPORT_RESERVED")
+        .blocklist_item("IPPORT_RESERVED")
         .generate()
         .expect("Failed to generate bindings");
 

--- a/libevent-sys/src/lib.rs
+++ b/libevent-sys/src/lib.rs
@@ -12,6 +12,7 @@
 #![allow(non_snake_case)]
 #![allow(clippy::unreadable_literal)]
 #![allow(clippy::redundant_static_lifetimes)]
+#![allow(clippy::missing_safety_doc)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 


### PR DESCRIPTION
Through trial and error, MSRV is also updated to 1.57 (from 1.47), and the Rust edition is updated to 2021 (from 2018).

This PR supersedes #18.