### PR TITLE
release: prep libevent-sys 0.2.6

### DIFF
--- a/libevent-sys/Cargo.toml
+++ b/libevent-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libevent-sys"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Steven vanZyl <rushsteve1@rushsteve1.us>",
            "Jon Magnuson <jon.magnuson@gmail.com>",
            "Grant Elbert <elbe0046@gmail.com>"]


### PR DESCRIPTION
Exposes the headers introduced in #19.

Resolves #21 